### PR TITLE
refactor: remove local formatBytes wrappers

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -232,7 +232,7 @@ class OllamaService {
             const enhancedModels = (data.models || []).map(model => ({
                 ...model,
                 displayName: model.name,
-                size: this.formatBytes(model.size),
+                size: SharedUtils.formatBytes(model.size),
                 capabilities: this.getModelCapabilities(model),
                 family: model.details?.family || 'unknown',
                 parameterSize: model.details?.parameter_size || 'unknown'
@@ -261,11 +261,6 @@ class OllamaService {
     isThinkingModel(modelName) {
         // Use shared utility to eliminate code duplication
         return ModelUtils.isThinkingModel(modelName);
-    }
-
-    formatBytes(bytes) {
-        // Use shared utility to eliminate code duplication
-        return SharedUtils.formatBytes(bytes);
     }
 
     async pullModel(modelName, progressCallback = null) {

--- a/settings.js
+++ b/settings.js
@@ -458,7 +458,7 @@ class SideLlamaSettings {
         }
 
         const modelElements = models.map(model => {
-            const memoryUsage = this.formatBytes(model.size_vram || model.size || 0);
+            const memoryUsage = SharedUtils.formatBytes(model.size_vram || model.size || 0);
             const duration = model.expires_at ? this.formatDuration(new Date(model.expires_at) - new Date()) : 'Indefinite';
             
             return `
@@ -475,11 +475,6 @@ class SideLlamaSettings {
         }).join('');
 
         this.runningModelsList.innerHTML = modelElements;
-    }
-
-    formatBytes(bytes) {
-        // Use shared utility to eliminate code duplication
-        return SharedUtils.formatBytes(bytes);
     }
 
     formatDuration(ms) {


### PR DESCRIPTION
## Summary
- remove redundant `formatBytes` helpers from service worker and settings
- use `SharedUtils.formatBytes` directly for size formatting

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68957850b47c83308465612956778f0c