### PR TITLE
refactor: centralize default settings

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -108,61 +108,7 @@ class OllamaService {
 
     async loadSettings() {
         const result = await chrome.storage.sync.get('sideLlamaSettings');
-        
-        // Default settings that match settings.js
-        const defaultSettings = {
-            ollamaUrl: 'http://localhost:11434',
-            enableToolCalls: true,
-            autoManageToolCalls: true, // Smart auto-configuration based on model capabilities
-            enableThinking: true, // Enable thinking mode for compatible models
-            defaultModel: 'qwen2.5:7b',
-            streamingEnabled: true,
-            systemPrompt: `You are SideLlama, a sophisticated and friendly AI assistant integrated into your browser. You are a knowledgeable and helpful companion for a wide range of tasks, from quick questions to in-depth research.
-
-**Your Persona:**
-- You are intelligent, kind, and proactive. You can lead the conversation and suggest new directions.
-- You are a master of markdown and use it to create beautiful, easy-to-read responses.
-- You enjoy thoughtful discussions about science, philosophy, and technology.
-
-**Your Capabilities:**
-- **Web Search:** You can search the web for up-to-date information.
-- **Vision:** You can analyze images and screenshots.
-- **Code Generation:** You can write and format code in various languages. You will always add comments to your code to explain what it does.
-- **Markdown Formatting:** You can create beautiful and easy-to-read responses using markdown.
-
-**Output Format:**
-- Use markdown for all responses.
-- Use headings, lists, and tables to organize information.
-- Use code blocks for code snippets, and always add comments to your code.
-- Use bold and italics to emphasize key points.
-- Keep your responses concise and to the point.`,
-            contextLength: 128000,
-            searchEngine: 'serper',
-            serperApiKey: '',
-            maxSearchResults: 5,
-            autoPageContext: false,
-            saveHistory: true,
-            maxHistoryLength: 100,
-            maxApiMessages: 5, // Updated to ultra-focused
-            screenshotQuality: 90,
-            // Advanced Model Parameters
-            temperature: 0.8,
-            topP: 0.9,
-            topK: 20,
-            seed: null,
-            repeatPenalty: 1.1,
-            enableAdvancedParams: false,
-            // Structured Outputs
-            outputFormat: 'auto',
-            enableStructuredOutput: false,
-            jsonSchema: '',
-            // Performance Settings
-            keepAlive: '5m',
-            showPerformanceStats: false,
-            autoRefreshModels: false,
-            // Thinking Display
-            showThinkingProcess: true
-        };
+        const { default: defaultSettings } = await import('./src/defaultSettings.js');
         
         this.settings = result.sideLlamaSettings || defaultSettings;
         

--- a/settings.html
+++ b/settings.html
@@ -560,6 +560,6 @@
     </div>
 
     <script src="shared-utils.js"></script>
-    <script src="settings.js"></script>
+    <script type="module" src="settings.js"></script>
 </body>
 </html>

--- a/settings.js
+++ b/settings.js
@@ -1,60 +1,9 @@
+import defaultSettings from './src/defaultSettings.js';
 // SideLlama Settings JavaScript
 
 class SideLlamaSettings {
     constructor() {
-        this.settings = {
-            ollamaUrl: 'http://localhost:11434',
-            enableToolCalls: true,
-            autoManageToolCalls: true, // Smart auto-configuration based on model capabilities
-            enableThinking: true, // Enable thinking mode for compatible models
-            defaultModel: 'qwen2.5:7b',
-            streamingEnabled: true, // Default to on - provides better UX
-            systemPrompt: `You are SideLlama, a sophisticated and friendly AI assistant integrated into your browser. You are a knowledgeable and helpful companion for a wide range of tasks, from quick questions to in-depth research.
-
-**Your Persona:**
-- You are intelligent, kind, and proactive. You can lead the conversation and suggest new directions.
-- You are a master of markdown and use it to create beautiful, easy-to-read responses.
-- You enjoy thoughtful discussions about science, philosophy, and technology.
-
-**Your Capabilities:**
-- **Web Search:** You can search the web for up-to-date information.
-- **Vision:** You can analyze images and screenshots.
-- **Code Generation:** You can write and format code in various languages. You will always add comments to your code to explain what it does.
-- **Markdown Formatting:** You can create beautiful and easy-to-read responses using markdown.
-
-**Output Format:**
-- Use markdown for all responses.
-- Use headings, lists, and tables to organize information.
-- Use code blocks for code snippets, and always add comments to your code.
-- Use bold and italics to emphasize key points.
-- Keep your responses concise and to the point.`,
-            contextLength: 128000,
-            searchEngine: 'serper',
-                                    serperApiKey: 'd03c7ebd4196bf9562d419973ae064',
-            maxSearchResults: 5,
-            autoPageContext: false,
-            saveHistory: true,
-            maxHistoryLength: 100,
-            maxApiMessages: 10,
-            screenshotQuality: 90,
-            // Advanced Model Parameters
-            temperature: 0.8,
-            topP: 0.9,
-            topK: 20,
-            seed: null,
-            repeatPenalty: 1.1,
-            enableAdvancedParams: false,
-            // Structured Outputs
-            outputFormat: 'auto', // 'auto', 'json', 'schema'
-            enableStructuredOutput: false,
-            jsonSchema: '',
-            // Performance Settings
-            keepAlive: '5m',
-            showPerformanceStats: false,
-            autoRefreshModels: false,
-            // Thinking Display
-            showThinkingProcess: true
-        };
+        this.settings = { ...defaultSettings };
         
         this.initializeElements();
         this.loadSettings();

--- a/src/defaultSettings.js
+++ b/src/defaultSettings.js
@@ -1,0 +1,57 @@
+export const defaultSettings = {
+    ollamaUrl: 'http://localhost:11434',
+    enableToolCalls: true,
+    autoManageToolCalls: true, // Smart auto-configuration based on model capabilities
+    enableThinking: true, // Enable thinking mode for compatible models
+    defaultModel: 'qwen2.5:7b',
+    streamingEnabled: true,
+    systemPrompt: `You are SideLlama, a sophisticated and friendly AI assistant integrated into your browser. You are a
+knowledgeable and helpful companion for a wide range of tasks, from quick questions to in-depth research.
+
+**Your Persona:**
+- You are intelligent, kind, and proactive. You can lead the conversation and suggest new directions.
+- You are a master of markdown and use it to create beautiful, easy-to-read responses.
+- You enjoy thoughtful discussions about science, philosophy, and technology.
+
+**Your Capabilities:**
+- **Web Search:** You can search the web for up-to-date information.
+- **Vision:** You can analyze images and screenshots.
+- **Code Generation:** You can write and format code in various languages. You will always add comments to your code to explain
+what it does.
+- **Markdown Formatting:** You can create beautiful and easy-to-read responses using markdown.
+
+**Output Format:**
+- Use markdown for all responses.
+- Use headings, lists, and tables to organize information.
+- Use code blocks for code snippets, and always add comments to your code.
+- Use bold and italics to emphasize key points.
+- Keep your responses concise and to the point.`,
+    contextLength: 128000,
+    searchEngine: 'serper',
+    serperApiKey: '',
+    maxSearchResults: 5,
+    autoPageContext: false,
+    saveHistory: true,
+    maxHistoryLength: 100,
+    maxApiMessages: 5, // Updated to ultra-focused
+    screenshotQuality: 90,
+    // Advanced Model Parameters
+    temperature: 0.8,
+    topP: 0.9,
+    topK: 20,
+    seed: null,
+    repeatPenalty: 1.1,
+    enableAdvancedParams: false,
+    // Structured Outputs
+    outputFormat: 'auto',
+    enableStructuredOutput: false,
+    jsonSchema: '',
+    // Performance Settings
+    keepAlive: '5m',
+    showPerformanceStats: false,
+    autoRefreshModels: false,
+    // Thinking Display
+    showThinkingProcess: true
+};
+
+export default defaultSettings;


### PR DESCRIPTION
## Summary
- add shared `defaultSettings` module
- load defaults in service worker and settings via import
- mark settings script as module for ES imports

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68957819d9ec83308ed89944bfc3bd31